### PR TITLE
⚡ Bolt: Add in-memory cache for getScoreboard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-15 - In-Memory Scoreboard Caching
+**Learning:** `getScoreboard` is called frequently whenever lobby state updates are broadcasted to all users, resulting in repetitive database queries for the top 10 played games. The TimeVirus backend currently uses a single Node.js instance architecture, making in-memory caching safe.
+**Action:** Implemented a simple module-level `cachedScoreboard` variable in `updateScoreBoard.service.ts` to cache the latest scoreboard data and invalidate it upon new game completion, significantly reducing MongoDB read operations.

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -41,7 +41,7 @@ const startServer = async () => {
 	httpServer.listen(PORT);
 };
 
-startServer().catch((err) => {
+startServer().catch((err: unknown) => {
 	console.error("🛑 Failed to initialize backend state", err);
 	process.exit(1);
 });

--- a/backend/src/services/updateScoreBoard.service.ts
+++ b/backend/src/services/updateScoreBoard.service.ts
@@ -1,8 +1,12 @@
 import { ScoreBoardPayload } from "@shared/types/payloads.types.ts";
 import { prisma } from "../lib/prisma.ts";
 
+// Cache for the top 10 scoreboard to prevent unnecessary DB queries
+// on every lobby update.
+let cachedScoreboard: { name: string | null; player_one_name: string; player_two_name: string; player_one_score: number; player_two_score: number; createdAt: Date; }[] | null = null;
+
 export const createScoreboard = async (payload: ScoreBoardPayload) => {
-    return await prisma.scoreboard.create({
+    const result = await prisma.scoreboard.create({
         data: {
             name: payload.name,
             player_one_name: payload.player_one_name,
@@ -11,10 +15,20 @@ export const createScoreboard = async (payload: ScoreBoardPayload) => {
             player_two_score: payload.player_two_score,
         }
     });
+
+    // Invalidate the cache when a new game is completed and added to the scoreboard
+    cachedScoreboard = null;
+
+    return result;
 }
 
 export const getScoreboard = async () => {
-    return await prisma.scoreboard.findMany({
+    // Return cached scoreboard if it exists
+    if (cachedScoreboard !== null) {
+        return cachedScoreboard;
+    }
+
+    const result = await prisma.scoreboard.findMany({
         orderBy: {
             createdAt: "desc",
         },
@@ -23,4 +37,7 @@ export const getScoreboard = async () => {
             id: true,
         }
     });
+    cachedScoreboard = result;
+
+    return result;
 }


### PR DESCRIPTION
💡 **What:** Added a simple module-level `cachedScoreboard` variable to cache the top 10 scoreboard games and return them without hitting the database on every `updateLobbyForAll` call. The cache is successfully invalidated (`cachedScoreboard = null`) whenever a new game finishes and is inserted via `createScoreboard`.
🎯 **Why:** `getScoreboard` is triggered frequently whenever a player joins, leaves, or a game ends (through `updateLobbyForAll` broadcast). This caused an unnecessary load of database read operations despite the data not changing most of the time.
📊 **Impact:** Expected to significantly reduce MongoDB read operations for the `/lobby` and overall server CPU utilization, as the scoreboard fetching is now O(1) in-memory rather than a network + DB call on every lobby state change.
🔬 **Measurement:** Observe DB read metrics; they should drop substantially during regular gameplay compared to baseline. Check that the lobby correctly updates when a new game finishes.

---
*PR created automatically by Jules for task [13073355536690459419](https://jules.google.com/task/13073355536690459419) started by @KaptenKatthatt*