### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in frontend templates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [XSS] Missing HTML encoding on user-controlled names
+**Vulnerability:** XSS vulnerability in multiple frontend components (`Livematches.ts`, `Scoreboard.ts`, `gameover.ts`, `PlayerCard.ts`, `main.ts`, etc.) where user-controlled player names are rendered directly into the DOM using `innerHTML` or `textContent` without escaping.
+**Learning:** Whenever injecting user-controlled data into HTML using `.innerHTML` or template literals, it must be properly HTML escaped to prevent execution of arbitrary JavaScript. A utility function `escapeHtml` is present in `Chat.ts` but is not reused across the application.
+**Prevention:** Extract the `escapeHtml` function into a shared utility (`utils/sanitize.ts` or similar) and apply it to all user-provided data rendered in HTML templates.

--- a/frontend/src/components/Chat.ts
+++ b/frontend/src/components/Chat.ts
@@ -1,5 +1,6 @@
 import type { AppClientSocket } from "../types/socket.types";
 import type { ChatMessage, OnlinePlayer } from "@shared/types/payloads.types";
+import { escapeHtml } from "../utils/sanitize";
 
 export default function Chat(socket: AppClientSocket, initialPlayers: OnlinePlayer[]) {
 	const wrapper = document.createElement("div");
@@ -96,12 +97,4 @@ export default function Chat(socket: AppClientSocket, initialPlayers: OnlinePlay
 		addMessage,
 		updatePlayers: (players: OnlinePlayer[]) => renderPlayers(players),
 	};
-}
-
-function escapeHtml(str: string): string {
-	return str
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
 }

--- a/frontend/src/components/Livematches.ts
+++ b/frontend/src/components/Livematches.ts
@@ -1,4 +1,5 @@
 import type { LiveGameData } from "@shared/types/payloads.types";
+import { escapeHtml } from "../utils/sanitize";
 
 export default function Livematches(liveGames: LiveGameData[]) {
 	const render = () => {
@@ -64,7 +65,7 @@ function LiveMatchItem(name: string, score: number) {
 		div.className = "d-flex p-3 flex-column justify-content-center align-items-center gap-2";
 
 		div.innerHTML = `
-			<span>${name}</span>
+			<span>${escapeHtml(name)}</span>
 			<span>${score}</span>
 		`;
 

--- a/frontend/src/components/Scoreboard.ts
+++ b/frontend/src/components/Scoreboard.ts
@@ -1,4 +1,5 @@
 import type { ScoreBoardPayload } from "@shared/types/payloads.types";
+import { escapeHtml } from "../utils/sanitize";
 
 export default function Scoreboard(data: ScoreBoardPayload[]) {
 	const render = () => {
@@ -81,7 +82,7 @@ function GameResultItem(name: string, score: number, winner: string) {
 		}
 
 		div.innerHTML = `
-			<span>${name}</span>
+			<span>${escapeHtml(name)}</span>
 			<span>${score}</span>
 		`;
 

--- a/frontend/src/components/game/PlayerCard.ts
+++ b/frontend/src/components/game/PlayerCard.ts
@@ -1,5 +1,6 @@
 import type { PlayerPayload } from "../../types/game.types";
 import { timeFormatter } from "../../utils/timeFormatter";
+import { escapeHtml } from "../../utils/sanitize";
 
 export function PlayerCard(player: PlayerPayload, socketId: string) {
 	let playerId = player.id;
@@ -13,7 +14,7 @@ export function PlayerCard(player: PlayerPayload, socketId: string) {
 			"d-flex justify-content-evenly flex-column bg-dark align-items-center p-4 border-img-dark";
 
 		div.innerHTML = `
-			<span class="name ${isMe} display-lg-5 display-6">${name}</span>
+			<span class="name ${isMe} display-lg-5 display-6">${escapeHtml(name)}</span>
 			<span class="player-reaction-time fs-2">00:00</span>
 		`;
 		const reactionTimeEl = div.querySelector<HTMLSpanElement>(".player-reaction-time")!;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -26,6 +26,7 @@ import type {
 } from "@shared/types/payloads.types";
 import type { AppClientSocket } from "./types/socket.types";
 import { APP_FADE_DURATION_MS, applyFadeDurationCssVar } from "./lib/fadeConfig";
+import { escapeHtml } from "./utils/sanitize";
 
 const SOCKET_HOST = import.meta.env.VITE_SOCKET_HOST;
 console.log("🙇 Connecting to Socket.IO Server at:", SOCKET_HOST);
@@ -337,7 +338,7 @@ function buildSinglePlayerResult(data: GameOverPayload): HTMLElement {
 			"d-flex fs-1 px-5 py-4 flex-column justify-content-center align-items-center gap-2";
 		item.innerHTML = `
 			${isWinner ? '<span class="winnerIcon">👑</span>' : '<span class="loserIcon">😭</span>'}
-			<span class="${isWinner ? "text-primary fw-bold winnerStyle" : ""}">${name}</span>
+			<span class="${isWinner ? "text-primary fw-bold winnerStyle" : ""}">${escapeHtml(name)}</span>
 			<span>${score}</span>
 		`;
 		return item;

--- a/frontend/src/pages/gameover.ts
+++ b/frontend/src/pages/gameover.ts
@@ -3,6 +3,7 @@ import Button from "../components/Button";
 import type { ClientToServerEvents, ServerToClientEvents } from "@shared/types/SocketEvents.types";
 import type { GameOverPayload } from "@shared/types/payloads.types";
 import { DisconnectedUser, RematchModal } from "../components/LobbyModals";
+import { escapeHtml } from "../utils/sanitize";
 
 export default function GameOver(
 	socket: Socket<ServerToClientEvents, ClientToServerEvents>,
@@ -135,7 +136,7 @@ function ResultItem(data: { name: string; score: number; isWinner: boolean }) {
 
 		div.innerHTML = `
 			${winnerStyle ? '<span class="winnerIcon">👑</span>' : '<span class="loserIcon">😭</span>'}
-			<span class="${winnerStyle}">${name}</span>
+			<span class="${winnerStyle}">${escapeHtml(name)}</span>
 			<span>${score}</span>
 		`;
 

--- a/frontend/src/utils/sanitize.ts
+++ b/frontend/src/utils/sanitize.ts
@@ -1,0 +1,1 @@
+export function escapeHtml(str: string): string { return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;"); }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "Time Virus Jonas Olson",
-  "version": "1.0.0",
+  "name": "time-virus-jonas-olson",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Time Virus Jonas Olson",
-      "version": "1.0.0",
+      "name": "time-virus-jonas-olson",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Multiple frontend components (e.g., Scoreboard, Livematches, gameover, PlayerCard, main) were directly injecting user-controlled data (player names) into the DOM using `.innerHTML` without proper HTML encoding, leading to potential Cross-Site Scripting (XSS).
🎯 Impact: An attacker could set a malicious payload as their username to execute arbitrary JavaScript in other players' browsers.
🔧 Fix: Extracted the `escapeHtml` function from `Chat.ts` into a shared `utils/sanitize.ts` utility and applied it to all vulnerable templates across the application.
✅ Verification: Review the source changes to confirm `escapeHtml` wraps `name` interpolations. Running the test suite (`cd frontend && npm run check`) passes cleanly.

---
*PR created automatically by Jules for task [15041120243519148962](https://jules.google.com/task/15041120243519148962) started by @KaptenKatthatt*