### PR TITLE
⚡ Bolt: Cache scoreboard database queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - In-memory Caching in Single-Instance Architecture
+**Learning:** The backend maintains state (like `activeGames`) in memory, which indicates a single-instance architecture. This allows for simple, effective in-memory caching (like caching DB query results for the lobby scoreboard) without needing to worry about distributed caching or synchronization issues.
+**Action:** When frequently querying relatively static data (e.g. recent scoreboards) that is updated in the same instance, use a simple in-memory cache variable instead of hitting the DB on every event.

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -41,7 +41,7 @@ const startServer = async () => {
 	httpServer.listen(PORT);
 };
 
-startServer().catch((err) => {
+startServer().catch((err: unknown) => {
 	console.error("🛑 Failed to initialize backend state", err);
 	process.exit(1);
 });

--- a/backend/src/services/updateScoreBoard.service.ts
+++ b/backend/src/services/updateScoreBoard.service.ts
@@ -1,8 +1,12 @@
 import { ScoreBoardPayload } from "@shared/types/payloads.types.ts";
 import { prisma } from "../lib/prisma.ts";
 
+// ⚡ Bolt: Cache to store the latest 10 scoreboard entries
+// Avoids repeated DB queries on every lobby update since backend is a single instance.
+let cachedScoreboard: Awaited<ReturnType<typeof _getScoreboardDb>> | null = null;
+
 export const createScoreboard = async (payload: ScoreBoardPayload) => {
-    return await prisma.scoreboard.create({
+    const result = await prisma.scoreboard.create({
         data: {
             name: payload.name,
             player_one_name: payload.player_one_name,
@@ -11,9 +15,13 @@ export const createScoreboard = async (payload: ScoreBoardPayload) => {
             player_two_score: payload.player_two_score,
         }
     });
+
+    // ⚡ Bolt: Invalidate cache when a new score is added
+    cachedScoreboard = null;
+    return result;
 }
 
-export const getScoreboard = async () => {
+const _getScoreboardDb = async () => {
     return await prisma.scoreboard.findMany({
         orderBy: {
             createdAt: "desc",
@@ -23,4 +31,14 @@ export const getScoreboard = async () => {
             id: true,
         }
     });
+}
+
+export const getScoreboard = async () => {
+    // ⚡ Bolt: Return cached scoreboard to prevent DB query on every lobby update
+    if (cachedScoreboard !== null) {
+        return cachedScoreboard;
+    }
+
+    cachedScoreboard = await _getScoreboardDb();
+    return cachedScoreboard;
 }


### PR DESCRIPTION
**💡 What:** Implemented a simple in-memory cache for the `getScoreboard` database query in `updateScoreBoard.service.ts`. The cache stores the 10 most recent scoreboard entries and is invalidated only when a new score is added.

**🎯 Why:** The application frequently sends lobby updates to all users (on connect, disconnect, game start, game over, join game). This triggers the `buildLobbyUpdate` function, which previously ran an expensive `findMany` MongoDB query via Prisma on every event. Given the single-instance architecture of the backend, hitting the DB on every event for data that rarely changes is a major bottleneck.

**📊 Impact:** Drastically reduces MongoDB query volume for the application. For N active connections and events, scoreboard read queries drop from O(N) to O(1) between completed games.

**🔬 Measurement:** Start the backend server and observe DB query logs (or monitor via Prisma studio/MongoDB metrics). Connect multiple clients and trigger events (like joining/leaving). You will see the DB query count for scoreboard entries remain at 1 until a new game finishes and a new score is stored.

---
*PR created automatically by Jules for task [7232943695755202063](https://jules.google.com/task/7232943695755202063) started by @KaptenKatthatt*