### PR TITLE
⚡ Bolt: Add in-memory cache for scoreboard to optimize lobby updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Lobby Update Frequency and In-Memory Caching
+**Learning:** `buildLobbyUpdate` is called extremely frequently (connect, disconnect, numerous game events). Calling un-cached database queries inside this payload generation creates a significant performance bottleneck. However, the backend maintains a single-instance architecture (in-memory `activeGames`), allowing for simple, safe in-memory caching strategies without distributed synchronization issues.
+**Action:** When working on lobby or frequently broadcast payload generation, always cache database results in memory and invalidate only on explicit write operations.

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -41,7 +41,7 @@ const startServer = async () => {
 	httpServer.listen(PORT);
 };
 
-startServer().catch((err) => {
+startServer().catch((err: unknown) => {
 	console.error("🛑 Failed to initialize backend state", err);
 	process.exit(1);
 });

--- a/backend/src/services/updateScoreBoard.service.ts
+++ b/backend/src/services/updateScoreBoard.service.ts
@@ -1,8 +1,12 @@
 import { ScoreBoardPayload } from "@shared/types/payloads.types.ts";
 import { prisma } from "../lib/prisma.ts";
 
+// In-memory cache for the scoreboard to prevent frequent database queries
+// during lobby updates. Safe to use due to single-instance backend architecture.
+let scoreboardCache: Omit<ScoreBoardPayload, 'id'>[] | null = null;
+
 export const createScoreboard = async (payload: ScoreBoardPayload) => {
-    return await prisma.scoreboard.create({
+    const result = await prisma.scoreboard.create({
         data: {
             name: payload.name,
             player_one_name: payload.player_one_name,
@@ -11,10 +15,19 @@ export const createScoreboard = async (payload: ScoreBoardPayload) => {
             player_two_score: payload.player_two_score,
         }
     });
+
+    // Invalidate the cache when a new scoreboard entry is created
+    scoreboardCache = null;
+
+    return result;
 }
 
 export const getScoreboard = async () => {
-    return await prisma.scoreboard.findMany({
+    if (scoreboardCache) {
+        return scoreboardCache;
+    }
+
+    const results = await prisma.scoreboard.findMany({
         orderBy: {
             createdAt: "desc",
         },
@@ -23,4 +36,7 @@ export const getScoreboard = async () => {
             id: true,
         }
     });
+
+    scoreboardCache = results;
+    return results;
 }


### PR DESCRIPTION
💡 **What**: Added an in-memory cache for the `getScoreboard` database query, which returns the top 10 played games. The cache is invalidated automatically when a new scoreboard entry is created. Also, typed an unknown error object in `server.ts` to satisfy `npm run check`.
🎯 **Why**: `buildLobbyUpdate` is called extremely frequently (upon connects, disconnects, game starts, round completions, etc.) to broadcast lobby state to clients. Querying the database un-cached for every payload generation causes an unnecessary performance bottleneck. The backend's single-instance architecture makes a simple memory cache perfectly safe without complex synchronization.
📊 **Impact**: Reduces database read load significantly during periods of high lobby activity. 
🔬 **Measurement**: Verified the logic locally; tests and `npm run check` pass cleanly. Performance improvement can be measured by monitoring the database query volume for the `Scoreboard` collection compared to lobby traffic.

---
*PR created automatically by Jules for task [2910840729744540838](https://jules.google.com/task/2910840729744540838) started by @KaptenKatthatt*