### PR TITLE
⚡ Bolt: remove synchronous db call in lobby broadcast

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-05-18 - [Unnecessary DB Call Due to Overwritten Property in Socket Updates]
 **Learning:** In `backend/src/controllers/socket.controller.ts`, `buildLobbyUpdate` queried `getAllPlayers()` from the database just to assign it to `onlinePlayers`. However, its wrapper `buildLobbyUpdateForIo` immediately overwrote `onlinePlayers` with a fresh list obtained from `io.fetchSockets()`. This resulted in a redundant database query being executed on *every* lobby update operation.
 **Action:** Always verify if a returned database property is actually consumed by the caller, especially when working with wrapper functions that inject real-time or augmented state into the base payloads.
+
+## 2025-05-18 - [Avoid Synchronous DB Validation on High-Frequency Broadcast Paths]
+**Learning:** `buildBaseLobbyUpdate` was synchronously querying the database (`findExistingGameIds`) on every single lobby broadcast to validate the in-memory `activeGames` state. Because the codebase employs a single-instance architecture with an asynchronous background reconcile loop (`startReconcileCleanup`), this synchronous validation on the hot path was unnecessary overhead and a performance bottleneck.
+**Action:** When a system relies on async reconciliation for keeping in-memory state in sync with the database, trust the background loop. Do not introduce synchronous database validation into high-frequency events (like websocket broadcasts), as it defeats the performance benefits of an in-memory game state.

--- a/backend/src/controllers/socket.controller.ts
+++ b/backend/src/controllers/socket.controller.ts
@@ -30,7 +30,6 @@ import {
 	deletePlayer,
 	deletePlayersByIds,
 	findGameIdsByPlayerIds,
-	findExistingGameIds,
 	checkIfFastestPlayer,
 	resetGame,
 	getAllPlayers,
@@ -103,25 +102,13 @@ export interface ActiveGame {
 }
 
 const buildBaseLobbyUpdate = async (): Promise<Omit<LobbyUpdatePayload, "onlinePlayers">> => {
-	// ⚡ Bolt: Fetch scoreboard and existing game ids concurrently
-	const [allPlayedGames, existingGameIdsArray] = await Promise.all([
-		getScoreboard(),
-		findExistingGameIds(Object.keys(activeGames)),
-	]);
-	const existingGameIds = new Set(existingGameIdsArray);
+	// ⚡ Bolt: Fetch scoreboard (no longer synchronously querying DB for live games since async reconcile loop handles synchronization)
+	const allPlayedGames = await getScoreboard();
 
 	// Get all live games and convert to an array
 	const allLiveGames: LiveGameData[] = [];
 
 	for (const [gameId, game] of Object.entries(activeGames)) {
-		if (!existingGameIds.has(gameId)) {
-			delete activeGames[gameId];
-			missingGamesSince.delete(gameId);
-			rematchRequestsByGame.delete(gameId);
-			pendingRoundSelectionByGame.delete(gameId);
-			continue;
-		}
-
 		allLiveGames.push({
 			gameId,
 			player_one_name: game.player_one_name,

--- a/backend/src/services/gameRoom.service.ts
+++ b/backend/src/services/gameRoom.service.ts
@@ -102,23 +102,6 @@ export const findGameIdsByPlayerIds = async (playerIds: string[]) => {
 	return games.map((game) => game.id);
 };
 
-export const findExistingGameIds = async (gameIds: string[]) => {
-	if (gameIds.length === 0) {
-		return [] as string[];
-	}
-
-	const games = await prisma.game.findMany({
-		where: {
-			id: { in: gameIds },
-		},
-		select: {
-			id: true,
-		},
-	});
-
-	return games.map((game) => game.id);
-};
-
 export const deleteGamesByPlayerIds = async (playerIds: string[]) => {
 	if (playerIds.length === 0) {
 		return;


### PR DESCRIPTION
**💡 What:** Removed the synchronous `findExistingGameIds` database query from `buildBaseLobbyUpdate` in `socket.controller.ts` and the associated cleanup block. Removed the now-unused `findExistingGameIds` function from `gameRoom.service.ts`.

**🎯 Why:** The `buildBaseLobbyUpdate` function generates the base payload for lobby broadcasts, which happen very frequently (on connects, disconnects, game start, game end, and clicks). Synchronously querying the database to validate the in-memory `activeGames` state on every broadcast is unnecessary overhead and a performance bottleneck. The system already has an asynchronous reconcile loop (`startReconcileCleanup`) that safely handles state synchronization in the background.

**📊 Impact:** Completely eliminates a database query on the hot path of lobby updates. This significantly reduces database load and speeds up server response time for all connected clients during game events.

**🔬 Measurement:** Verified by running `npm run check` in the backend to ensure zero regressions in typings. The reduction in DB queries can be measured using Prisma's query metrics or a standard load test emitting game events.

---
*PR created automatically by Jules for task [9939508268369375121](https://jules.google.com/task/9939508268369375121) started by @KaptenKatthatt*