### PR TITLE
⚡ Bolt: remove sync DB query inside high-frequency lobby broadcast loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-05-18 - [Unnecessary DB Call Due to Overwritten Property in Socket Updates]
 **Learning:** In `backend/src/controllers/socket.controller.ts`, `buildLobbyUpdate` queried `getAllPlayers()` from the database just to assign it to `onlinePlayers`. However, its wrapper `buildLobbyUpdateForIo` immediately overwrote `onlinePlayers` with a fresh list obtained from `io.fetchSockets()`. This resulted in a redundant database query being executed on *every* lobby update operation.
 **Action:** Always verify if a returned database property is actually consumed by the caller, especially when working with wrapper functions that inject real-time or augmented state into the base payloads.
+
+## 2026-05-22 - [Synchronous DB Validation Inside High-Frequency Broadcast Loop]
+**Learning:** In `backend/src/controllers/socket.controller.ts`, `buildBaseLobbyUpdate` called `findExistingGameIds` to validate `activeGames` from the database. Since `buildBaseLobbyUpdate` was called on almost every event as part of `updateLobbyForAll`, this created a significant performance bottleneck. Given the backend maintains `activeGames` naturally via connection handlers and an async reconcile loop (`startReconcileCleanup`), doing synchronous DB validation inside the broadcast payload construction is unnecessary.
+**Action:** Avoid placing heavy or un-cached DB queries in payload generators for frequently emitted lobby events. Trust the asynchronous sync processes for in-memory live states when generating frequent payload broadcasts.

--- a/backend/src/controllers/socket.controller.ts
+++ b/backend/src/controllers/socket.controller.ts
@@ -30,7 +30,6 @@ import {
 	deletePlayer,
 	deletePlayersByIds,
 	findGameIdsByPlayerIds,
-	findExistingGameIds,
 	checkIfFastestPlayer,
 	resetGame,
 	getAllPlayers,
@@ -103,25 +102,15 @@ export interface ActiveGame {
 }
 
 const buildBaseLobbyUpdate = async (): Promise<Omit<LobbyUpdatePayload, "onlinePlayers">> => {
-	// ⚡ Bolt: Fetch scoreboard and existing game ids concurrently
-	const [allPlayedGames, existingGameIdsArray] = await Promise.all([
-		getScoreboard(),
-		findExistingGameIds(Object.keys(activeGames)),
-	]);
-	const existingGameIds = new Set(existingGameIdsArray);
+	// ⚡ Bolt: Fetch scoreboard.
+	// Removed synchronous DB validation of `activeGames` since it creates a bottleneck during frequent lobby updates.
+	// `activeGames` is naturally kept in sync by connection handlers and `startReconcileCleanup`.
+	const allPlayedGames = await getScoreboard();
 
 	// Get all live games and convert to an array
 	const allLiveGames: LiveGameData[] = [];
 
 	for (const [gameId, game] of Object.entries(activeGames)) {
-		if (!existingGameIds.has(gameId)) {
-			delete activeGames[gameId];
-			missingGamesSince.delete(gameId);
-			rematchRequestsByGame.delete(gameId);
-			pendingRoundSelectionByGame.delete(gameId);
-			continue;
-		}
-
 		allLiveGames.push({
 			gameId,
 			player_one_name: game.player_one_name,


### PR DESCRIPTION
💡 What: Removed the synchronous `findExistingGameIds` database query from `buildBaseLobbyUpdate`, relying instead on the existing in-memory `activeGames` state.

🎯 Why: The backend frequently emits lobby updates via `updateLobbyForAll` on connect, disconnect, and many game events. Performing a synchronous database validation of the live games inside this payload builder creates a significant performance bottleneck. The application already handles distributed state synchronization via an asynchronous reconcile loop (`startReconcileCleanup`) and connection handler logic, making this specific DB call redundant and slow.

📊 Impact: Reduces database load significantly by eliminating an un-cached query from the high-frequency event loop. This leads to faster and more responsive lobby updates for all players.

🔬 Measurement: Verify the change by checking database query logs or running load tests that simulate many users rapidly connecting/disconnecting or triggering events; the total number of queries per second should be considerably lower.

---
*PR created automatically by Jules for task [6013498599656116986](https://jules.google.com/task/6013498599656116986) started by @KaptenKatthatt*