### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing Input Length Validation on playerJoinLobbyRequest

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The application blindly destructured and assumed the presence of nested properties on payloads sent from WebSocket clients in various `socket.on` events.
 **Learning:** Sending malicious or malformed `null` or structurally-invalid payloads like `socket.emit("chat:message", null)` triggered a `TypeError` (e.g., `TypeError: Cannot destructure property 'message' of 'object null'`) that could crash the entire backend process. Unchecked destructuring of user-provided data directly creates DoS risks in node servers.
 **Prevention:** Always ensure payloads are checked to be objects (e.g., `typeof payload === "object" && payload !== null`) and validate the expected types of properties inside before destructuring or executing logic upon them.
+## 2024-05-23 - Missing input length validation DoS vulnerability
+**Vulnerability:** Socket.io event payload `playerName` lacked length limits, enabling potential memory exhaustion/DoS attack.
+**Learning:** Even simple socket parameters like a string name require upper bound length validations to protect the system memory and database performance.
+**Prevention:** Always implement maximum length constraints or truncation on unvalidated text inputs across all endpoints, specially when parsing directly from user provided buffers.

--- a/backend/src/controllers/socket.controller.ts
+++ b/backend/src/controllers/socket.controller.ts
@@ -365,7 +365,7 @@ export const handleConnection = (socket: AppSocket, io: AppServer) => {
 	 */
 	socket.on("playerJoinLobbyRequest", async (playerName: string) => {
 		try {
-			if (typeof playerName !== "string") {
+			if (typeof playerName !== "string" || playerName.length > 20) {
 				return;
 			}
 			// Save player name on socket for global use


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `playerJoinLobbyRequest` event handler in the backend did not validate the length of the `playerName` input.
🎯 Impact: A malicious user could send an excessively large string as `playerName`, potentially causing a Denial of Service (DoS) attack by exhausting server memory or database resources, and causing huge payloads to be broadcast to all connected players.
🔧 Fix: Added a length validation check `playerName.length > 20` to reject requests with excessively long player names, conforming to safe upper boundaries.
✅ Verification: Tested and verified that valid short names continue to work, while names exceeding 20 characters are appropriately rejected early. Run `npm run check` and verified it passes cleanly.

---
*PR created automatically by Jules for task [6625074950706499217](https://jules.google.com/task/6625074950706499217) started by @KaptenKatthatt*