### PR TITLE
⚡ Bolt: Optimize lobby update by removing synchronous DB query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-05-18 - [Unnecessary DB Call Due to Overwritten Property in Socket Updates]
 **Learning:** In `backend/src/controllers/socket.controller.ts`, `buildLobbyUpdate` queried `getAllPlayers()` from the database just to assign it to `onlinePlayers`. However, its wrapper `buildLobbyUpdateForIo` immediately overwrote `onlinePlayers` with a fresh list obtained from `io.fetchSockets()`. This resulted in a redundant database query being executed on *every* lobby update operation.
 **Action:** Always verify if a returned database property is actually consumed by the caller, especially when working with wrapper functions that inject real-time or augmented state into the base payloads.
+
+## 2025-05-25 - [Redundant Synchronous Database Validation in Lobby Update]
+**Learning:** In `backend/src/controllers/socket.controller.ts`, `buildBaseLobbyUpdate` queried `findExistingGameIds` synchronously to validate the `activeGames` in-memory store before generating the lobby payload. Since `activeGames` is natively kept in sync through connection handlers (and cleaned via an async reconcile loop `startReconcileCleanup`), querying the database synchronously on every lobby update creates an unnecessary performance bottleneck.
+**Action:** Avoid placing heavy synchronous or un-cached database queries inside frequently broadcast payload generators, especially when an async process already handles state synchronization.

--- a/backend/src/controllers/socket.controller.ts
+++ b/backend/src/controllers/socket.controller.ts
@@ -30,7 +30,6 @@ import {
 	deletePlayer,
 	deletePlayersByIds,
 	findGameIdsByPlayerIds,
-	findExistingGameIds,
 	checkIfFastestPlayer,
 	resetGame,
 	getAllPlayers,
@@ -103,25 +102,14 @@ export interface ActiveGame {
 }
 
 const buildBaseLobbyUpdate = async (): Promise<Omit<LobbyUpdatePayload, "onlinePlayers">> => {
-	// ⚡ Bolt: Fetch scoreboard and existing game ids concurrently
-	const [allPlayedGames, existingGameIdsArray] = await Promise.all([
-		getScoreboard(),
-		findExistingGameIds(Object.keys(activeGames)),
-	]);
-	const existingGameIds = new Set(existingGameIdsArray);
+	// ⚡ Bolt: Fetch scoreboard
+	// Removed redundant findExistingGameIds() DB query since activeGames state is synchronized async
+	const allPlayedGames = await getScoreboard();
 
 	// Get all live games and convert to an array
 	const allLiveGames: LiveGameData[] = [];
 
 	for (const [gameId, game] of Object.entries(activeGames)) {
-		if (!existingGameIds.has(gameId)) {
-			delete activeGames[gameId];
-			missingGamesSince.delete(gameId);
-			rematchRequestsByGame.delete(gameId);
-			pendingRoundSelectionByGame.delete(gameId);
-			continue;
-		}
-
 		allLiveGames.push({
 			gameId,
 			player_one_name: game.player_one_name,


### PR DESCRIPTION
💡 **What:** Removed the synchronous `findExistingGameIds` database query from `buildBaseLobbyUpdate`.
🎯 **Why:** The `buildBaseLobbyUpdate` function executes frequently to broadcast lobby updates to clients. Querying the database to validate the `activeGames` in-memory object on every broadcast creates a severe performance bottleneck. The `activeGames` state is naturally maintained by connection handlers and periodically cleaned up by an async background loop (`startReconcileCleanup`), so synchronous validation during the read path is unnecessary.
📊 **Impact:** Substantially reduces database load and latency during lobby broadcasts by eliminating an un-cached N-key database lookup.
🔬 **Measurement:** Validate that the application boots and socket connection broadcasts successfully via `npm run check`. Load testing socket connections should show a noticeable reduction in MongoDB query logs.

---
*PR created automatically by Jules for task [3361218642993091752](https://jules.google.com/task/3361218642993091752) started by @KaptenKatthatt*