### PR TITLE
⚡ Bolt: Remove synchronous DB validation from lobby broadcast

### DIFF
--- a/backend/src/controllers/socket.controller.ts
+++ b/backend/src/controllers/socket.controller.ts
@@ -103,25 +103,15 @@ export interface ActiveGame {
 }
 
 const buildBaseLobbyUpdate = async (): Promise<Omit<LobbyUpdatePayload, "onlinePlayers">> => {
-	// ⚡ Bolt: Fetch scoreboard and existing game ids concurrently
-	const [allPlayedGames, existingGameIdsArray] = await Promise.all([
-		getScoreboard(),
-		findExistingGameIds(Object.keys(activeGames)),
-	]);
-	const existingGameIds = new Set(existingGameIdsArray);
+	// ⚡ Bolt: Fetch scoreboard and construct live games directly from in-memory state
+	// Ghost game cleanup is delegated to the async startReconcileCleanup background task
+	// to avoid synchronous DB validation on every broadcast
+	const allPlayedGames = await getScoreboard();
 
 	// Get all live games and convert to an array
 	const allLiveGames: LiveGameData[] = [];
 
 	for (const [gameId, game] of Object.entries(activeGames)) {
-		if (!existingGameIds.has(gameId)) {
-			delete activeGames[gameId];
-			missingGamesSince.delete(gameId);
-			rematchRequestsByGame.delete(gameId);
-			pendingRoundSelectionByGame.delete(gameId);
-			continue;
-		}
-
 		allLiveGames.push({
 			gameId,
 			player_one_name: game.player_one_name,
@@ -253,11 +243,17 @@ export const startReconcileCleanup = (io: AppServer) => {
 				}
 			}
 
-			if (stalePlayerIds.length === 0 && staleGameIdsFromMemory.length === 0) {
+			// ⚡ Bolt: Check for ghost games in memory that no longer exist in the DB
+			const inMemoryGameIds = Object.keys(activeGames);
+			const existingDbGameIdsArray = await findExistingGameIds(inMemoryGameIds);
+			const existingDbGameIds = new Set(existingDbGameIdsArray);
+			const ghostGameIdsFromMemory = inMemoryGameIds.filter(id => !existingDbGameIds.has(id));
+
+			if (stalePlayerIds.length === 0 && staleGameIdsFromMemory.length === 0 && ghostGameIdsFromMemory.length === 0) {
 				return;
 			}
 
-			const staleGameIds = new Set(staleGameIdsFromMemory);
+			const staleGameIds = new Set([...staleGameIdsFromMemory, ...ghostGameIdsFromMemory]);
 			for (const gameId of await findGameIdsByPlayerIds(stalePlayerIds)) {
 				staleGameIds.add(gameId);
 			}


### PR DESCRIPTION
💡 **What**: Moved synchronous database queries (`findExistingGameIds`) used for filtering out ghost games away from `buildBaseLobbyUpdate`, opting instead to construct the list of `allLiveGames` directly from the `activeGames` map. Cleanup of ghost games has been shifted to the asynchronous `startReconcileCleanup` function, which runs in the background.

🎯 **Why**: When building the lobby update, querying the database to see which games from the in-memory `activeGames` object still existed blocked the hot-path event broadcast loop. Since the backend frequently broadcasts lobby updates to all connected players (and on new connections), the concurrent connection count significantly amplified this performance penalty, essentially creating an N+1-like broadcast bottleneck.

📊 **Impact**: Massively reduces latency of `buildBaseLobbyUpdate` and subsequent websocket broadcasts. With this change, payload assembly operates mostly in-memory (and via the `scoreboard` cache).

🔬 **Measurement**: Measure the execution time of `buildLobbyUpdateForIo()` with vs without this patch during moderate simulated concurrent player events (e.g. 50+ sockets actively connecting/disconnecting). This reduces execution time to O(N_in_memory_games) memory access vs an external asynchronous database call for each round.

---
*PR created automatically by Jules for task [15205195180409822879](https://jules.google.com/task/15205195180409822879) started by @KaptenKatthatt*