### PR TITLE
🛡️ Sentinel: [HIGH] Fix Authorization Bypass in Game State

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,7 +7,13 @@
 **Vulnerability:** The application blindly destructured and assumed the presence of nested properties on payloads sent from WebSocket clients in various `socket.on` events.
 **Learning:** Sending malicious or malformed `null` or structurally-invalid payloads like `socket.emit("chat:message", null)` triggered a `TypeError` (e.g., `TypeError: Cannot destructure property 'message' of 'object null'`) that could crash the entire backend process. Unchecked destructuring of user-provided data directly creates DoS risks in node servers.
 **Prevention:** Always ensure payloads are checked to be objects (e.g., `typeof payload === "object" && payload !== null`) and validate the expected types of properties inside before destructuring or executing logic upon them.
+
 ## 2025-05-14 - IDOR Vulnerability via Socket.IO
 **Vulnerability:** The application was vulnerable to Insecure Direct Object Reference (IDOR) because multiple Socket.IO event handlers trusted the `playerId` provided by the client in the event payload.
 **Learning:** In a websocket setting, relying on client-provided identifiers for sensitive actions (like deleting a game or registering a player) allows attackers to impersonate other users simply by changing the ID in the payload. While the fix adds verification that the provided ID matches the socket ID, a more robust architectural pattern is to drop the payload parameter entirely and extract the trusted ID directly from `socket.id`.
 **Prevention:** Never trust client-provided identifiers when the server already possesses the authenticated/trusted identifier (like `socket.id` or a session token).
+
+## 2025-05-14 - Authorization Bypass in Game State
+**Vulnerability:** The application trusted client-provided reaction times (`timestampPayload.timestamp`) and failed to enforce a single-click-per-round limit in the `player:clicked` socket.io event.
+**Learning:** Clients could send a negative timestamp to artificially guarantee they are the fastest player. Additionally, because duplicate submissions weren't prevented, a malicious client could rapidly submit multiple click events in a row to rack up points for the same round, effectively bypassing the opponent's turn and cheating the game state.
+**Prevention:** Always validate numeric inputs from clients (e.g., `reactionTime >= 0`) and strictly enforce state transitions or actions on the server (e.g., verify `clickedPlayers` array does not already contain the user before accepting another click event).

--- a/backend/src/controllers/socket.controller.ts
+++ b/backend/src/controllers/socket.controller.ts
@@ -664,6 +664,14 @@ export const handleConnection = (socket: AppSocket, io: AppServer) => {
 		//Player reaction time
 		const reactionTime = timestampPayload.timestamp;
 
+		// 🛡️ Sentinel: Validate that reactionTime isn't artificially negative and player hasn't already clicked
+		if (reactionTime < 0) {
+			return;
+		}
+		if (currentGame.clickedPlayers.some((p) => p.playerId === timestampPayload.playerId)) {
+			return;
+		}
+
 		const reactionDataPayLoad: ReactionData = {
 			playerId: timestampPayload.playerId,
 			reactionTime,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "Time Virus Jonas Olson",
-  "version": "1.0.0",
+  "name": "time-virus-jonas-olson",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Time Virus Jonas Olson",
-      "version": "1.0.0",
+      "name": "time-virus-jonas-olson",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `player:clicked` event blindly trusted the reaction time from clients and allowed duplicate submissions per round, leading to an authorization bypass and cheating vulnerability.
🎯 Impact: An attacker could send a negative timestamp to artificially guarantee they are the fastest player, or they could submit multiple click events in a single round to score points rapidly, bypassing the opponent entirely.
🔧 Fix: Added validations in `backend/src/controllers/socket.controller.ts` to drop the event if `reactionTime` is negative, or if the `playerId` has already registered a click in the current round.
✅ Verification: Ensure the fix passes by checking the backend test suite (`cd backend && npm run check`).

---
*PR created automatically by Jules for task [1292936780837693162](https://jules.google.com/task/1292936780837693162) started by @KaptenKatthatt*