### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent internal path disclosure in 404 handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The application used wildcard CORS configuration ('origin: "*"' in Socket.io and 'app.use(cors())' without arguments in Express), which allowed any website to make cross-origin requests to the API and WebSocket server.
 **Learning:** Default CORS configurations are often overly permissive. While useful during initial development, they expose the application to CSRF-like attacks and unauthorized data access in production environments.
 **Prevention:** Always restrict CORS origins to explicitly allowed domains using environment variables (e.g., 'process.env.CORS_ORIGIN'). When allowing credentials, a specific origin must be provided instead of a wildcard.
+
+## 2025-05-14 - Internal Path Disclosure in 404 Handler
+**Vulnerability:** The application's catch-all 404 error handler returned the absolute file path of the server's unresolved frontend build directory (`frontendDistPathResolved`) directly in the HTTP response body.
+**Learning:** Returning internal file paths or server configurations in error messages leads to Information Disclosure, exposing the server's directory structure to potential attackers, which could aid in subsequent targeted attacks.
+**Prevention:** Always use generic, non-revealing error messages in production error handlers and refrain from exposing internal state variables, stack traces, or absolute file paths.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,7 +38,7 @@ if (fs.existsSync(frontendDistPathResolved)) {
 	// Catch-all route handler with message about missing frontend build
 	app.use((_req, res) => {
 		// Respond with 404 and a message in JSON-format
-		res.status(404).send(`Frontend build does not exist at ${frontendDistPathResolved}`);
+		res.status(404).send(`Frontend build is not available.`);
 	});
 }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application's catch-all 404 error handler returned the absolute file path of the server's unresolved frontend build directory directly in the HTTP response body.
🎯 **Impact:** Information Disclosure. Returning internal file paths exposes the server's directory structure to potential attackers, which could aid in subsequent targeted attacks.
🔧 **Fix:** Replaced the absolute path in the response with a generic error message ("Frontend build is not available.").
✅ **Verification:** Ran backend and frontend check scripts to ensure no type regressions. Verified the diff does not include the sensitive internal variable.

---
*PR created automatically by Jules for task [14228560626722062921](https://jules.google.com/task/14228560626722062921) started by @KaptenKatthatt*