### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The application used wildcard CORS configuration ('origin: "*"' in Socket.io and 'app.use(cors())' without arguments in Express), which allowed any website to make cross-origin requests to the API and WebSocket server.
 **Learning:** Default CORS configurations are often overly permissive. While useful during initial development, they expose the application to CSRF-like attacks and unauthorized data access in production environments.
 **Prevention:** Always restrict CORS origins to explicitly allowed domains using environment variables (e.g., 'process.env.CORS_ORIGIN'). When allowing credentials, a specific origin must be provided instead of a wildcard.
+
+## 2025-05-14 - Information Disclosure in Express 404 Handler
+**Vulnerability:** The Express 404 catch-all route (used when the frontend build is missing) exposed the absolute internal server directory path (`frontendDistPathResolved`) in the HTTP response body sent to external users.
+**Learning:** Returning server-side paths directly to users exposes internal directory structures and the underlying operating system setup, aiding attackers in planning further exploits (like path traversal attacks).
+**Prevention:** Always return generic error messages to clients (e.g., "Frontend build not found") and log the sensitive detailed errors, including file paths, only on the server side (e.g., via `console.warn`).

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -37,8 +37,8 @@ if (fs.existsSync(frontendDistPathResolved)) {
 
 	// Catch-all route handler with message about missing frontend build
 	app.use((_req, res) => {
-		// Respond with 404 and a message in JSON-format
-		res.status(404).send(`Frontend build does not exist at ${frontendDistPathResolved}`);
+		// 🛡️ Security: Avoid exposing absolute file paths in HTTP responses to prevent Information Disclosure vulnerabilities
+		res.status(404).send("Frontend build not found");
 	});
 }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Express 404 catch-all route (triggered when the frontend build is missing) exposed the absolute internal server directory path (`frontendDistPathResolved`) in the HTTP response body sent to external users.
🎯 **Impact:** Exposing server-side paths aids attackers in planning further exploits, like path traversal attacks, by revealing the internal directory structure and underlying operating system setup.
🔧 **Fix:** Changed the Express route to return a generic "Frontend build not found" error message instead of the absolute file path. Added a security comment explaining the rationale.
✅ **Verification:** Verified by checking the updated route logic and running `npm run check` in the backend. Also logged the vulnerability in the Sentinel journal.

---
*PR created automatically by Jules for task [13503602008324607987](https://jules.google.com/task/13503602008324607987) started by @KaptenKatthatt*