### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Express 404 handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The application used wildcard CORS configuration ('origin: "*"' in Socket.io and 'app.use(cors())' without arguments in Express), which allowed any website to make cross-origin requests to the API and WebSocket server.
 **Learning:** Default CORS configurations are often overly permissive. While useful during initial development, they expose the application to CSRF-like attacks and unauthorized data access in production environments.
 **Prevention:** Always restrict CORS origins to explicitly allowed domains using environment variables (e.g., 'process.env.CORS_ORIGIN'). When allowing credentials, a specific origin must be provided instead of a wildcard.
+
+## 2024-06-21 - Information Disclosure in Express 404 Handler
+**Vulnerability:** The Express fallback 404 handler in `backend/src/app.ts` directly returned the absolute server file path (`frontendDistPathResolved`) in its plain text error response when the frontend build was not found.
+**Learning:** Returning unhandled or verbose error responses can unintentionally leak internal directory structures, which attackers could leverage to map out the server environment for further path traversal or local file inclusion exploits.
+**Prevention:** Always use generic, predictable error messages (e.g., `{"error": "Not Found"}`) in production endpoints, especially for catch-all 404 or 500 handlers. Do not interpolate server paths or stack traces into client-facing responses.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,7 +38,7 @@ if (fs.existsSync(frontendDistPathResolved)) {
 	// Catch-all route handler with message about missing frontend build
 	app.use((_req, res) => {
 		// Respond with 404 and a message in JSON-format
-		res.status(404).send(`Frontend build does not exist at ${frontendDistPathResolved}`);
+		res.status(404).json({ error: "Not Found" });
 	});
 }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure. The Express catch-all 404 handler in `backend/src/app.ts` was returning the absolute server file path (`frontendDistPathResolved`) to the client when the frontend build was not found.
🎯 Impact: Attackers could hit missing endpoints and learn the exact internal directory structure of the Node backend, which aids in path traversal or other reconnaissance.
🔧 Fix: Replaced the verbose string message with a generic `{"error": "Not Found"}` JSON response.
✅ Verification: Ensure the app builds and runs, and hitting an unhandled backend route correctly returns `{"error": "Not Found"}` without exposing paths. Ran `npm run check` and updated `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16612294777715174970](https://jules.google.com/task/16612294777715174970) started by @KaptenKatthatt*