### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in 404 handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,7 @@
 **Vulnerability:** The application used wildcard CORS configuration ('origin: "*"' in Socket.io and 'app.use(cors())' without arguments in Express), which allowed any website to make cross-origin requests to the API and WebSocket server.
 **Learning:** Default CORS configurations are often overly permissive. While useful during initial development, they expose the application to CSRF-like attacks and unauthorized data access in production environments.
 **Prevention:** Always restrict CORS origins to explicitly allowed domains using environment variables (e.g., 'process.env.CORS_ORIGIN'). When allowing credentials, a specific origin must be provided instead of a wildcard.
+## 2024-05-18 - Information Disclosure in Express 404 Handler
+**Vulnerability:** The Express fallback 404 error handler for serving the frontend build was returning `res.status(404).send(\`Frontend build does not exist at ${frontendDistPathResolved}\`);`, which exposed the absolute internal server directory path to the client.
+**Learning:** Returning resolved or absolute system paths directly to clients leaks internal environment context, which could potentially be used to craft path traversal or environment-specific exploits.
+**Prevention:** Always use generic error messages for end-users, logging the sensitive system details (like absolute paths) to the server console instead. Use `res.status(404).json({ error: "Generic message" });`.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -37,8 +37,8 @@ if (fs.existsSync(frontendDistPathResolved)) {
 
 	// Catch-all route handler with message about missing frontend build
 	app.use((_req, res) => {
-		// Respond with 404 and a message in JSON-format
-		res.status(404).send(`Frontend build does not exist at ${frontendDistPathResolved}`);
+		// Respond with 404 and a generic message in JSON-format to prevent path disclosure
+		res.status(404).json({ error: "Frontend build not found" });
 	});
 }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Express fallback 404 error handler for missing frontend builds was returning `res.status(404).send(\`Frontend build does not exist at ${frontendDistPathResolved}\`);`, which exposed the absolute internal server directory path to the client.
🎯 **Impact:** Exposing internal directory structures leaks sensitive environment context to attackers, which could aid in crafting path traversal or environment-specific exploits.
🔧 **Fix:** Modified the 404 error response to return a generic JSON message (`res.status(404).json({ error: "Frontend build not found" });`), failing securely without leaking system details.
✅ **Verification:** Verified by checking the updated route handler in `backend/src/app.ts` and confirming that the project compiles correctly via `cd backend && npm run check`. Additionally logged learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4636105560420106126](https://jules.google.com/task/4636105560420106126) started by @KaptenKatthatt*