### PR TITLE
⚡ Bolt: Prevent expensive string-to-DOM parsing in Score updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-06-05 - [Unnecessary Object and String Allocations in Hot Paths]
 **Learning:** High-frequency operations, like emitting `lobby:update` to all users via `updateLobbyForAll`, suffered from unnecessary object allocation when using the spread operator (`{ ...lobbyData }`) simply to pass an existing payload object. Additionally, string manipulation utilities like `escapeHtml` used chained `.replace()` calls which created multiple intermediate strings.
 **Action:** Avoid redundant object spread operators when emitting existing payload objects in frequent socket events. Use a single-pass regex replacement with a map for string manipulation functions called frequently in render loops to reduce memory allocation pressure.
+## 2026-06-06 - [Preventing expensive string-to-DOM parsing in frequent state updates]
+**Learning:** The `Score` component in the frontend was recreating elements using `.innerHTML` on every socket broadcast/update. This required the browser to parse strings into DOM elements frequently, leading to unnecessary main thread blockages.
+**Action:** Replace `.innerHTML` string interpolation with targeted `.textContent` mutations on preserved DOM references for components that update constantly during hot paths (e.g., game state handlers or score updates).

--- a/frontend/src/components/game/Score.ts
+++ b/frontend/src/components/game/Score.ts
@@ -9,13 +9,23 @@ export function Score(playerOne: PlayerPayload, playerTwo: PlayerPayload, socket
 		div.className =
 			"d-flex justify-content-center align-items-center display-5 bg-dark gap-4 border-img-dark p-4";
 
+		// ⚡ Bolt: Expose targeted DOM node updates for .textContent to prevent expensive .innerHTML string-to-DOM parsing overhead during high-frequency game updates
 		div.innerHTML = `
-			<span class="${isMe}">${playerOne.score}</span>
+			<span class="player-one-score ${isMe}">${playerOne.score}</span>
 			<span>-</span>
-			<span class="${isPlayerTwo}">${playerTwo.score}</span>
+			<span class="player-two-score ${isPlayerTwo}">${playerTwo.score}</span>
 		`;
 
-		return div;
+		const playerOneScoreEl = div.querySelector<HTMLSpanElement>(".player-one-score")!;
+		const playerTwoScoreEl = div.querySelector<HTMLSpanElement>(".player-two-score")!;
+
+		return {
+			element: div,
+			updateScores: (playerOneScore: number, playerTwoScore: number) => {
+				playerOneScoreEl.textContent = String(playerOneScore);
+				playerTwoScoreEl.textContent = String(playerTwoScore);
+			},
+		};
 	};
 	return render();
 }

--- a/frontend/src/pages/game.ts
+++ b/frontend/src/pages/game.ts
@@ -44,7 +44,7 @@ export default function Game(socket: AppClientSocket) {
 	let disconnectedModal: HTMLDivElement | null = null;
 
 	const setupGameDataListeners = (
-		score: HTMLDivElement,
+		scoreComponent: ReturnType<typeof Score>,
 		roundNbrEl: HTMLSpanElement,
 		roundTotalEl: HTMLSpanElement,
 	) => {
@@ -69,8 +69,7 @@ export default function Game(socket: AppClientSocket) {
 				player1Card.updatePlayerId(player1Data.id);
 				player2Card.updatePlayerId(player2Data.id);
 
-				const updatedScore = Score(player1Data, player2Data, socket.id!);
-				score.innerHTML = updatedScore.innerHTML;
+				scoreComponent.updateScores(player1Data.score, player2Data.score);
 
 				// Update round nbr
 				if (payload.round) {
@@ -234,21 +233,21 @@ export default function Game(socket: AppClientSocket) {
 
 		const board = GameBoard();
 
-		const score = Score(player1Data, player2Data, socket.id!);
+		const scoreComponent = Score(player1Data, player2Data, socket.id!);
 
 		player1Card = PlayerCard(player1Data, socket.id!);
 		player2Card = PlayerCard(player2Data, socket.id!);
 
 		gameStatus.element.classList.add("game-info-card");
-		score.classList.add("game-info-card");
+		scoreComponent.element.classList.add("game-info-card");
 		player1Card.element.classList.add("game-info-card");
 		player2Card.element.classList.add("game-info-card");
 
 		setupVirusListeners(board, gameTimerEl);
-		setupGameDataListeners(score, roundNbrEl, roundTotalEl);
+		setupGameDataListeners(scoreComponent, roundNbrEl, roundTotalEl);
 
 		aside.appendChild(gameStatus.element);
-		aside.appendChild(score);
+		aside.appendChild(scoreComponent.element);
 		aside.appendChild(player1Card.element);
 		aside.appendChild(player2Card.element);
 

--- a/frontend/src/pages/singlePlayerGame.ts
+++ b/frontend/src/pages/singlePlayerGame.ts
@@ -42,19 +42,14 @@ export default function SinglePlayerGame(playerName: string, totalRounds = 3) {
 	// Component refs – assigned during render()
 	let player1Card: PlayerCardReturn;
 	let player2Card: PlayerCardReturn;
-	let scoreEl: HTMLDivElement;
+	let scoreComponent: ReturnType<typeof Score>;
 	let board: HTMLDivElement;
 	let roundNbrEl: HTMLSpanElement;
 	let roundTotalEl: HTMLSpanElement;
 	let gameTimerEl: HTMLSpanElement;
 
 	const updateScoreDisplay = () => {
-		const updated = Score(
-			{ ...playerData, score: playerScore },
-			{ ...cpuData, score: cpuScore },
-			PLAYER_ID,
-		);
-		scoreEl.innerHTML = updated.innerHTML;
+		scoreComponent.updateScores(playerScore, cpuScore);
 	};
 
 	const endGame = () => {
@@ -172,7 +167,7 @@ export default function SinglePlayerGame(playerName: string, totalRounds = 3) {
 
 		board = GameBoard();
 
-		scoreEl = Score(
+		scoreComponent = Score(
 			{ ...playerData, score: playerScore },
 			{ ...cpuData, score: cpuScore },
 			PLAYER_ID,
@@ -181,12 +176,12 @@ export default function SinglePlayerGame(playerName: string, totalRounds = 3) {
 		player2Card = PlayerCard({ ...cpuData }, PLAYER_ID);
 
 		gameStatus.element.classList.add("game-info-card");
-		scoreEl.classList.add("game-info-card");
+		scoreComponent.element.classList.add("game-info-card");
 		player1Card.element.classList.add("game-info-card");
 		player2Card.element.classList.add("game-info-card");
 
 		aside.appendChild(gameStatus.element);
-		aside.appendChild(scoreEl);
+		aside.appendChild(scoreComponent.element);
 		aside.appendChild(player1Card.element);
 		aside.appendChild(player2Card.element);
 


### PR DESCRIPTION
💡 **What:** The `Score` frontend component was refactored to expose an `updateScores` method instead of returning just an HTML string/element that would be injected via `.innerHTML`. The new method updates `.textContent` on preserved DOM node references directly. 

🎯 **Why:** Previously, the `Score` component would re-render via `element.innerHTML = otherElement.innerHTML` on every single socket event related to score changes. Using `.innerHTML` forces the browser to discard old DOM nodes, parse strings into HTML elements, and rebuild the DOM tree, causing an expensive block on the main thread during high-frequency real-time updates.

📊 **Impact:** Reduces main-thread rendering overhead for game scores significantly during high-frequency socket events. Prevents unnecessary DOM node tear-down and allocations.

🔬 **Measurement:** Execute `npm run check` inside `frontend/` to ensure no linting/type regressions. Profiling the Performance tab in Chrome DevTools during gameplay will show reduced parse time and layout thrashing.

---
*PR created automatically by Jules for task [7647515347274307104](https://jules.google.com/task/7647515347274307104) started by @KaptenKatthatt*